### PR TITLE
Add locale-based redirects for showcase PDF

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,32 @@
 import createNextIntlPlugin from "next-intl/plugin"
 
+const locales = ["en", "es"]
 const withNextIntl = createNextIntlPlugin()
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
     remotePatterns: [new URL("https://farox.coop/**")],
+  },
+
+  async redirects() {
+    const redirectsArray = []
+
+    redirectsArray.push({
+      source: "/showcase",
+      destination: "/showcase.pdf",
+      permanent: true,
+    })
+
+    for (const locale of locales) {
+      redirectsArray.push({
+        source: `/${locale}/showcase`,
+        destination: "/showcase.pdf",
+        permanent: true,
+      })
+    }
+
+    return redirectsArray
   },
 }
 


### PR DESCRIPTION
This pull request updates the Next.js configuration to enhance internationalization support and add custom redirect logic for the `/showcase` route. The main changes are the introduction of locale-aware redirects and the definition of supported locales.

Internationalization and Redirects:

* Added a `locales` array to support English (`en`) and Spanish (`es`) for internationalized routes.
* Implemented a custom `redirects` function that permanently redirects both `/showcase` and locale-prefixed `/en/showcase` and `/es/showcase` routes to `/showcase.pdf`.